### PR TITLE
refactor test cases for sudoku and IPv4 checkers

### DIFF
--- a/src/week_one/sudoku_checker/SudokuChecker.kt
+++ b/src/week_one/sudoku_checker/SudokuChecker.kt
@@ -5,6 +5,7 @@ package week_one.sudoku_checker
  * 1. No repeating values in the row.
  * 2. No repeating values in the column.
  * 3. No repeating values in subgrid of 3x3.
+ * 4. Only numbers from 1 to 9 are allowed
  *
  * Otherwise, it's invalid.
  */

--- a/test/week_one/ipv4_checker/IPv4CheckerTest.kt
+++ b/test/week_one/ipv4_checker/IPv4CheckerTest.kt
@@ -3,69 +3,89 @@ package week_one.ipv4_checker
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
+import week_one.ipv4_checker.fakes.FakeDataSource.fakeInValidFormatIPv4Address
+import week_one.ipv4_checker.fakes.FakeDataSource.fakeInvalidEmptySegmentIPv4Address
+import week_one.ipv4_checker.fakes.FakeDataSource.fakeInvalidExceedMaxNumberIPv4Address
+import week_one.ipv4_checker.fakes.FakeDataSource.fakeInvalidExceedMinNumberIPv4Address
 import week_one.ipv4_checker.fakes.FakeDataSource.fakeInvalidLeadingZerosIPv4Address
-import week_one.ipv4_checker.fakes.FakeDataSource.fakeInvalidNonAllowedCharsIPv4Address
-import week_one.ipv4_checker.fakes.FakeDataSource.fakeInvalidNotFourSegemntsIPv4Address
-import week_one.ipv4_checker.fakes.FakeDataSource.fakeInvalidOutRangeNumbersIPv4Address
-import week_one.ipv4_checker.fakes.FakeDataSource.fakeInvalidtionsIPv4Address
+import week_one.ipv4_checker.fakes.FakeDataSource.fakeInvalidNonNumericValuesIPv4Address
+import week_one.ipv4_checker.fakes.FakeDataSource.fakeInvalidWithLessSegmentsIPv4Address
+import week_one.ipv4_checker.fakes.FakeDataSource.fakeInvalidWithMoreSegmentsIPv4Address
 import week_one.ipv4_checker.fakes.FakeDataSource.fakeValidIPv4Address
 import week_one.ipv4_checker.fakes.FakeDataSource.fakeValidWithMaxNumberOnlyIPv4Address
-import week_one.ipv4_checker.fakes.FakeDataSource.fakeValidWithZeroOnlyIPv4Address
+import week_one.ipv4_checker.fakes.FakeDataSource.fakeValidWithMinNumberOnlyIPv4Address
 
 class IPv4CheckerTest {
 
     @Test
-    fun `test success checkIpv4Address, returns True`() {
+    fun `should return true, when IPv4 address is valid`() {
         val expectedResult = checkIpv4Address(fakeValidIPv4Address)
         assertTrue(expectedResult)
     }
 
     @Test
-    fun `test success checkIpv4Address with zero as a digit, returns True`() {
-        val expectedResult = checkIpv4Address(fakeValidWithZeroOnlyIPv4Address)
+    fun `should return true, when IPv4 address contains only min value`() {
+        val expectedResult = checkIpv4Address(fakeValidWithMinNumberOnlyIPv4Address)
         assertTrue(expectedResult)
     }
 
     @Test
-    fun `test success checkIpv4Address with 255 the max number, returns True`() {
+    fun `should return true, when IPv4 address contains only max value`() {
         val expectedResult = checkIpv4Address(fakeValidWithMaxNumberOnlyIPv4Address)
         assertTrue(expectedResult)
     }
 
     @Test
-    fun `test failure checkIpv4Address with number out of range, returns false`() {
-        val expectedResult = checkIpv4Address(fakeInvalidOutRangeNumbersIPv4Address)
+    fun `should return false, when IPv4 address segment exceed min value`() {
+        val expectedResult = checkIpv4Address(fakeInvalidExceedMinNumberIPv4Address)
         assertFalse(expectedResult)
     }
 
     @Test
-    fun `test failure checkIpv4Address with empty input, returns false`() {
+    fun `should return false, when IPv4 address segment exceed max value`() {
+        val expectedResult = checkIpv4Address(fakeInvalidExceedMaxNumberIPv4Address)
+        assertFalse(expectedResult)
+    }
+
+    @Test
+    fun `should return false, when IPv4 address is empty`() {
         val expectedResult = checkIpv4Address("")
         assertFalse(expectedResult)
     }
 
-    // this test case cover the case of containing only three dots
     @Test
-    fun `test failure checkIpv4Address with not four segment, returns false`() {
-        val expectedResult = checkIpv4Address(fakeInvalidNotFourSegemntsIPv4Address)
+    fun `should return false, when IPv4 address has an empty segment`() {
+        val expectedResult = checkIpv4Address(fakeInvalidEmptySegmentIPv4Address)
         assertFalse(expectedResult)
     }
 
     @Test
-    fun `test failure checkIpv4Address with leading zeros, returns false`() {
+    fun `should return false, when IPv4 address is less than four segments`() {
+        val expectedResult = checkIpv4Address(fakeInvalidWithLessSegmentsIPv4Address)
+        assertFalse(expectedResult)
+    }
+
+    @Test
+    fun `should return false, when IPv4 address is more than four segments`() {
+        val expectedResult = checkIpv4Address(fakeInvalidWithMoreSegmentsIPv4Address)
+        assertFalse(expectedResult)
+    }
+
+    @Test
+    fun `should return false, when IPv4 address has segment with leading zero`() {
         val expectedResult = checkIpv4Address(fakeInvalidLeadingZerosIPv4Address)
         assertFalse(expectedResult)
     }
 
     @Test
-    fun `test failure checkIpv4Address with non allowed characters, returns false`() {
-        val expectedResult = checkIpv4Address(fakeInvalidNonAllowedCharsIPv4Address)
+    fun `should return false, when IPv4 address has non numeric values`() {
+        val expectedResult = checkIpv4Address(fakeInvalidNonNumericValuesIPv4Address)
         assertFalse(expectedResult)
     }
 
     @Test
-    fun `test failure checkIpv4Address with non allowed format, returns false`() {
-        val expectedResult = checkIpv4Address(fakeInvalidtionsIPv4Address)
+    fun `should return false, when IPv4 address segments not divided by dots`() {
+        val expectedResult = checkIpv4Address(fakeInValidFormatIPv4Address)
         assertFalse(expectedResult)
     }
 

--- a/test/week_one/ipv4_checker/fakes/FakeDataSource.kt
+++ b/test/week_one/ipv4_checker/fakes/FakeDataSource.kt
@@ -3,13 +3,15 @@ package week_one.ipv4_checker.fakes
 object FakeDataSource {
 
     val fakeValidIPv4Address = "192.168.1.1"
-    val fakeValidWithZeroOnlyIPv4Address = "0.0.0.0"
+    val fakeValidWithMinNumberOnlyIPv4Address = "0.0.0.0"
     val fakeValidWithMaxNumberOnlyIPv4Address = "255.255.255.255"
 
-    val fakeInvalidOutRangeNumbersIPv4Address = "192.300.1.-1"
-    val fakeInvalidNotFourSegemntsIPv4Address = "193.255.1"
+    val fakeInvalidExceedMaxNumberIPv4Address = "192.256.1.1"
+    val fakeInvalidExceedMinNumberIPv4Address = "192.255.-1.1"
+    val fakeInvalidWithLessSegmentsIPv4Address = "193.255.1"
+    val fakeInvalidWithMoreSegmentsIPv4Address = "192.168.1.1.8"
     val fakeInvalidLeadingZerosIPv4Address = "093.255.01.12"
-    val fakeInvalidNonAllowedCharsIPv4Address = "1f3.43D.-@1.12"
-
-    val fakeInvalidtionsIPv4Address = "f3e.43D.-@1.02.130"
+    val fakeInvalidNonNumericValuesIPv4Address = "1f3.13D.1.12"
+    val fakeInvalidEmptySegmentIPv4Address = "163..1.12"
+    val fakeInValidFormatIPv4Address = "192,168;1;1"
 }

--- a/test/week_one/sudoku_checker/SudokuCheckerTest.kt
+++ b/test/week_one/sudoku_checker/SudokuCheckerTest.kt
@@ -3,55 +3,55 @@ package week_one.sudoku_checker
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
-import week_one.sudoku_checker.fakes.FakeDataSource.fakeEmptyFullyInvValidSudokuPuzzle
-import week_one.sudoku_checker.fakes.FakeDataSource.fakeEmptyPartiallyInvValidSudokuPuzzle
-import week_one.sudoku_checker.fakes.FakeDataSource.fakeInvalidColumnSudokuPuzzle
-import week_one.sudoku_checker.fakes.FakeDataSource.fakeInvalidRowSudokuPuzzle
-import week_one.sudoku_checker.fakes.FakeDataSource.fakeInvalidSubGridSudokuPuzzle
-import week_one.sudoku_checker.fakes.FakeDataSource.fakeInvalidationsSudokuPuzzle
+import week_one.sudoku_checker.fakes.FakeDataSource.fakeDuplicateInColumnSudokuPuzzle
+import week_one.sudoku_checker.fakes.FakeDataSource.fakeDuplicateInRowSudokuPuzzle
+import week_one.sudoku_checker.fakes.FakeDataSource.fakeDuplicateInSubGridSudokuPuzzle
+import week_one.sudoku_checker.fakes.FakeDataSource.fakeEmptyFullSudokuPuzzle
+import week_one.sudoku_checker.fakes.FakeDataSource.fakeEmptyPartiallySudokuPuzzle
+import week_one.sudoku_checker.fakes.FakeDataSource.fakeNonAllowedCharsInSudokuPuzzle
 import week_one.sudoku_checker.fakes.FakeDataSource.fakeValidSudokuPuzzle
 
 class SudokuCheckerTest {
 
  @Test
- fun `test success checkSudokuPuzzle, returns true`() {
+ fun `should return true, when Sudoku puzzle is valid`() {
   val expectedResult = checkSudokuPuzzle(fakeValidSudokuPuzzle)
   assertTrue(expectedResult)
  }
 
  @Test
- fun `test failure checkSudokuPuzzle fully empty puzzle, returns false`() {
-  val expectedResult = checkSudokuPuzzle(fakeEmptyFullyInvValidSudokuPuzzle)
+ fun `should return true, when Sudoku puzzle is fully empty`() {
+  val expectedResult = checkSudokuPuzzle(fakeEmptyFullSudokuPuzzle)
+  assertTrue(expectedResult)
+ }
+
+ @Test
+ fun `should return true, when Sudoku puzzle is partially empty`() {
+  val expectedResult = checkSudokuPuzzle(fakeEmptyPartiallySudokuPuzzle)
+  assertTrue(expectedResult)
+ }
+
+ @Test
+ fun `should return false, when Sudoku puzzle has non allowed chars`() {
+  val expectedResult = checkSudokuPuzzle(fakeNonAllowedCharsInSudokuPuzzle)
   assertFalse(expectedResult)
  }
 
  @Test
- fun `test failure checkSudokuPuzzle partially empty puzzle, returns false`() {
-  val expectedResult = checkSudokuPuzzle(fakeEmptyPartiallyInvValidSudokuPuzzle)
+ fun `should return false, when Sudoku puzzle has two or more duplicates in row`() {
+  val expectedResult = checkSudokuPuzzle(fakeDuplicateInRowSudokuPuzzle)
   assertFalse(expectedResult)
  }
 
  @Test
- fun `test failure checkSudokuPuzzle with repeated row, returns false`() {
-  val expectedResult = checkSudokuPuzzle(fakeInvalidRowSudokuPuzzle)
+ fun `should return false, when Sudoku puzzle has two or more duplicates in column`() {
+  val expectedResult = checkSudokuPuzzle(fakeDuplicateInColumnSudokuPuzzle)
   assertFalse(expectedResult)
  }
 
  @Test
- fun `test failure checkSudokuPuzzle with repeated column, returns false`() {
-  val expectedResult = checkSudokuPuzzle(fakeInvalidColumnSudokuPuzzle)
-  assertFalse(expectedResult)
- }
-
- @Test
- fun `test failure checkSudokuPuzzle with repeated subgrid, returns false`() {
-  val expectedResult = checkSudokuPuzzle(fakeInvalidSubGridSudokuPuzzle)
-  assertFalse(expectedResult)
- }
-
- @Test
- fun `test failure checkSudokuPuzzle with multiple invalidations, returns false`() {
-  val expectedResult = checkSudokuPuzzle(fakeInvalidationsSudokuPuzzle)
+ fun `should return false, when Sudoku puzzle has two or more duplicates in subgrid`() {
+  val expectedResult = checkSudokuPuzzle(fakeDuplicateInSubGridSudokuPuzzle)
   assertFalse(expectedResult)
  }
 

--- a/test/week_one/sudoku_checker/fakes/FakeDataSource.kt
+++ b/test/week_one/sudoku_checker/fakes/FakeDataSource.kt
@@ -6,41 +6,82 @@ object FakeDataSource {
         charArrayOf('5', '3', '4', '6', '7', '8', '9', '1', '2'),
         charArrayOf('6', '7', '2', '1', '9', '5', '3', '4', '8'),
         charArrayOf('1', '9', '8', '3', '4', '2', '5', '6', '7'),
+        charArrayOf('8', '5', '9', '7', '6', '1', '4', '2', '3'),
+        charArrayOf('4', '2', '6', '8', '5', '3', '7', '9', '1'),
+        charArrayOf('7', '1', '3', '9', '2', '4', '8', '5', '6'),
+        charArrayOf('9', '6', '1', '5', '3', '7', '2', '8', '4'),
+        charArrayOf('2', '8', '7', '4', '1', '9', '6', '3', '5'),
+        charArrayOf('3', '4', '5', '2', '8', '6', '1', '7', '9')
     )
 
-    val fakeEmptyFullyInvValidSudokuPuzzle = arrayOf(
+    val fakeEmptyFullSudokuPuzzle = arrayOf(
         charArrayOf('-', '-', '-', '-', '-', '-', '-', '-', '-'),
         charArrayOf('-', '-', '-', '-', '-', '-', '-', '-', '-'),
         charArrayOf('-', '-', '-', '-', '-', '-', '-', '-', '-'),
+        charArrayOf('-', '-', '-', '-', '-', '-', '-', '-', '-'),
+        charArrayOf('-', '-', '-', '-', '-', '-', '-', '-', '-'),
+        charArrayOf('-', '-', '-', '-', '-', '-', '-', '-', '-'),
+        charArrayOf('-', '-', '-', '-', '-', '-', '-', '-', '-'),
+        charArrayOf('-', '-', '-', '-', '-', '-', '-', '-', '-'),
+        charArrayOf('-', '-', '-', '-', '-', '-', '-', '-', '-')
     )
 
-    val fakeEmptyPartiallyInvValidSudokuPuzzle = arrayOf(
+    val fakeEmptyPartiallySudokuPuzzle = arrayOf(
         charArrayOf('5', '3', '-', '-', '7', '-', '-', '-', '-'),
         charArrayOf('6', '-', '-', '1', '9', '5', '-', '-', '-'),
         charArrayOf('-', '9', '8', '-', '-', '-', '-', '6', '-'),
+        charArrayOf('8', '-', '-', '-', '6', '-', '-', '-', '3'),
+        charArrayOf('4', '-', '-', '8', '-', '3', '-', '-', '1'),
+        charArrayOf('7', '-', '-', '-', '2', '-', '-', '-', '6'),
+        charArrayOf('-', '6', '-', '-', '-', '-', '2', '8', '-'),
+        charArrayOf('-', '-', '-', '4', '1', '9', '-', '-', '5'),
+        charArrayOf('-', '-', '-', '-', '8', '-', '-', '7', '9')
     )
 
-    val fakeInvalidRowSudokuPuzzle = arrayOf(
+    val fakeNonAllowedCharsInSudokuPuzzle = arrayOf(
+        charArrayOf('@', '3', '-', '-', '7', '-', '-', '-', '-'), // invalid character in this row '@'
+        charArrayOf('6', '-', '-', '1', '9', '5', '-', '-', '-'),
+        charArrayOf('-', '9', '8', '-', '-', '-', '-', '0', '-'), // invalid char in this row '0'
+        charArrayOf('8', '-', '-', '-', '6', '-', '-', '-', '3'),
+        charArrayOf('4', '-', '-', '8', '-', '3', '-', '-', '1'),
+        charArrayOf('7', '-', '-', '-', '2', '-', '-', '-', '6'),
+        charArrayOf('-', '6', '-', '-', '-', '-', '2', '8', '-'),
+        charArrayOf('-', '-', '-', '4', '1', '9', '-', '-', '5'),
+        charArrayOf('-', '-', '-', '-', '8', '-', '-', '7', '9')
+    )
+    val fakeDuplicateInRowSudokuPuzzle = arrayOf(
         charArrayOf('5', '3', '4', '6', '7', '4', '9', '1', '2'), // invalid in first row with two 4s
         charArrayOf('6', '7', '2', '1', '9', '5', '3', '4', '8'),
         charArrayOf('1', '9', '8', '3', '4', '2', '5', '6', '7'),
+        charArrayOf('8', '5', '9', '7', '6', '1', '4', '2', '3'),
+        charArrayOf('4', '2', '6', '8', '5', '3', '7', '9', '1'),
+        charArrayOf('7', '1', '3', '9', '2', '4', '8', '5', '6'),
+        charArrayOf('9', '6', '1', '5', '3', '7', '2', '8', '4'),
+        charArrayOf('2', '8', '7', '4', '1', '9', '6', '3', '5'),
+        charArrayOf('3', '4', '5', '2', '8', '6', '1', '7', '9')
     )
 
-    val fakeInvalidColumnSudokuPuzzle = arrayOf(
+    val fakeDuplicateInColumnSudokuPuzzle = arrayOf(
         charArrayOf('5', '3', '4', '6', '7', '8', '9', '1', '2'), // invalid in the second column with two 7s
         charArrayOf('6', '7', '2', '1', '9', '5', '3', '4', '8'),
         charArrayOf('1', '7', '8', '3', '4', '2', '5', '6', '7'),
+        charArrayOf('8', '5', '9', '7', '6', '1', '4', '2', '3'),
+        charArrayOf('4', '2', '6', '8', '5', '3', '7', '9', '1'),
+        charArrayOf('7', '1', '3', '9', '2', '4', '8', '5', '6'),
+        charArrayOf('9', '6', '1', '5', '3', '7', '2', '8', '4'),
+        charArrayOf('2', '8', '7', '4', '1', '9', '6', '3', '5'),
+        charArrayOf('3', '4', '5', '2', '8', '6', '1', '7', '9')
     )
 
-    val fakeInvalidSubGridSudokuPuzzle = arrayOf(
+    val fakeDuplicateInSubGridSudokuPuzzle = arrayOf(
         charArrayOf('5', '3', '4', '6', '7', '8', '9', '1', '2'), // invalid in the first subgrid with two 5s and 4s
         charArrayOf('6', '7', '2', '1', '9', '5', '3', '4', '8'),
         charArrayOf('4', '9', '5', '3', '4', '2', '5', '6', '7'),
-    )
-
-    val fakeInvalidationsSudokuPuzzle = arrayOf(
-        charArrayOf('5', '3', '4', '6', '7', '4', '9', '1', '2'), // All the above invalidation.
-        charArrayOf('6', '7', '2', '1', '9', '5', '3', '4', '8'),
-        charArrayOf('4', '7', '5', '3', '4', '2', '5', '6', '7'),
+        charArrayOf('8', '5', '9', '7', '6', '1', '4', '2', '3'),
+        charArrayOf('4', '2', '6', '8', '5', '3', '7', '9', '1'),
+        charArrayOf('7', '1', '3', '9', '2', '4', '8', '5', '6'),
+        charArrayOf('9', '6', '1', '5', '3', '7', '2', '8', '4'),
+        charArrayOf('2', '8', '7', '4', '1', '9', '6', '3', '5'),
+        charArrayOf('3', '4', '5', '2', '8', '6', '1', '7', '9')
     )
 }


### PR DESCRIPTION
- Change and unify the test names with this convention "_**Should_ExpectedBehavior_When_StateUnderTest**_"
- Delete unnecessary test cases
- Add testing for some edge cases scenario. ex: _Sudoku Puzzle should accept only values from 1 to 9, otherwise it's **Invalid_**
- Complete the Sudoku Puzzle to be 9x9.